### PR TITLE
Add API for Pattern-Based Stock Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ venv
 **/.env
 *.icloud
 
+/backend/env
+/backend/staticfiles

--- a/backend/marketfeed/serializers.py
+++ b/backend/marketfeed/serializers.py
@@ -50,8 +50,6 @@ class StockCreateSerializer(serializers.ModelSerializer):
             self.fields['currency'].required = True
 
 
-
-
 class StockHistoricDataSerializer(serializers.Serializer):
     start_date = serializers.DateField()  # Start date of the interval
     end_date = serializers.DateField()  # End date of the interval
@@ -69,8 +67,14 @@ class StockHistoricDataSerializer(serializers.Serializer):
 
         return value
 
+class StockPatternSearchSerializer(serializers.Serializer):
 
+    pattern = serializers.CharField(
+        required=True,
+        help_text="The pattern to search stock symbol and name for.",
+    )
 
+    limit = serializers.IntegerField(required=False, default=10)
 
 class TagSerializer(serializers.ModelSerializer):
     user_id = serializers.PrimaryKeyRelatedField(queryset=User.objects.all())

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       sh -c 'python3 manage.py makemigrations &&
              python3 manage.py migrate --noinput &&
              python3 manage.py collectstatic --noinput &&
+             python3 manage.py update_currencies && 
+             python3 manage.py update_stocks && 
              gunicorn backend.wsgi:application --bind 0.0.0.0:8000'
     restart: always
     environment:


### PR DESCRIPTION
Handling the portfolio page and adding assets requires us to search for stock names that match a given pattern. This PR introduces a new API endpoint that returns the most related stocks based on a given search pattern, with a configurable result limit. 

The changes include:
- A new `StockPatternSearchSerializer` to validate the pattern and limit parameters.
- A new `search` action in the `views.py` file that implements the search functionality.
- Docker Compose updates for the missing `update_stock` and `update_currencies` calls.
